### PR TITLE
Player moves correct amount of distance

### DIFF
--- a/my_game.py
+++ b/my_game.py
@@ -26,12 +26,10 @@ SCREEN_HEIGHT = MAP_HEIGHT * TILE_SIZE
 
 # Variables controlling the player
 PLAYER_LIVES = 3
-PLAYER_SPEED_X = 200
 PLAYER_START_X = SCREEN_WIDTH / 2
 PLAYER_START_Y = 50
 PLAYER_SHOT_SPEED = 300
 
-PLAYER_JUMP_DIST = 30
 
 FIRE_KEY = arcade.key.SPACE
 
@@ -58,8 +56,8 @@ class GameView(arcade.View):
             new_goal_sprite = arcade.Sprite(
                 texture=self.load_tilemap_textures[190],
                 scale=SPRITE_SCALING, 
-                center_x = layer_tile.center_x - (layer_tile.width/4),
-                center_y = layer_tile.center_y - (layer_tile.height/4)
+                center_x = layer_tile.center_x,
+                center_y = layer_tile.center_y,
             )
             self.goal_sprite_list.append(new_goal_sprite)
 
@@ -74,17 +72,6 @@ class GameView(arcade.View):
         )
 
         self.map = self.load_map()
-
-        # Add sprites from map physics engine
-        # This should only be done for some, if any, sprite lists
-        """
-        for layer_name, layer_sprites in self.map.sprite_lists.items():
-            print("Added map layer:", layer_name)
-            self.pe.add_sprite_list(
-                sprite_list=layer_sprites,
-                body_type=arcade.PymunkPhysicsEngine.STATIC
-                )
-        """
 
         # player spawns at random position from the start position layer
         for layer_name, layer_sprites in self.map.sprite_lists.items():
@@ -189,19 +176,14 @@ class GameView(arcade.View):
         # Calculate player speed based on the keys pressed
         self.player.change_x = 0
 
-        # Move player with keyboard
-        if self.left_pressed and not self.right_pressed:
-            self.player.change_x = -PLAYER_SPEED_X
-        elif self.right_pressed and not self.left_pressed:
-            self.player.change_x = PLAYER_SPEED_X
-
+        
         self.goal_sprite_list.update()
 
-        goal_hit_list = arcade.check_for_collision_with_list(self.player, self.goal_sprite_list)
+        #goal_hit_list = arcade.check_for_collision_with_list(self.player, self.goal_sprite_list)
 
-        for g in goal_hit_list:
+        #for g in goal_hit_list:
             # Remove the goal
-            g.remove_from_sprite_lists()
+        #    g.remove_from_sprite_lists()
 
         # Move player with joystick if present
         if self.joystick:
@@ -243,16 +225,16 @@ class GameView(arcade.View):
         # Track state of arrow keys
         if key == arcade.key.UP:
             self.up_pressed = True
-            new_pp = (new_pp[0], new_pp[1] + PLAYER_JUMP_DIST)
+            new_pp = (new_pp[0], new_pp[1] + TILE_SIZE)
         elif key == arcade.key.DOWN:
             self.down_pressed = True
-            new_pp = (new_pp[0], new_pp[1] - PLAYER_JUMP_DIST)
+            new_pp = (new_pp[0], new_pp[1] - TILE_SIZE)
         elif key == arcade.key.LEFT:
             self.left_pressed = True
-            new_pp = (new_pp[0] - PLAYER_JUMP_DIST, new_pp[1])
+            new_pp = (new_pp[0] - TILE_SIZE, new_pp[1])
         elif key == arcade.key.RIGHT:
             self.right_pressed = True
-            new_pp = (new_pp[0] + PLAYER_JUMP_DIST, new_pp[1])
+            new_pp = (new_pp[0] + TILE_SIZE, new_pp[1])
 
         self.pe.set_position(
             sprite=self.player,

--- a/my_game.py
+++ b/my_game.py
@@ -180,7 +180,6 @@ class GameView(arcade.View):
         self.goal_sprite_list.update()
 
         
-        #Why
         goal_hit_list = arcade.check_for_collision_with_list(self.player, self.goal_sprite_list)
 
         for g in goal_hit_list:
@@ -188,6 +187,7 @@ class GameView(arcade.View):
             g.remove_from_sprite_lists()
 
         """
+        # Movement using joystick is not correct. Still here if we want to implement joystick later
         # Move player with joystick if present
         if self.joystick:
             self.player.change_x = round(self.joystick.x) * PLAYER_SPEED_X

--- a/my_game.py
+++ b/my_game.py
@@ -54,7 +54,7 @@ class GameView(arcade.View):
         for layer_tile in self.map.sprite_lists["goal"]:
             # /4 tile offset considering neither tile nor goal sprite has position in the center
             new_goal_sprite = arcade.Sprite(
-                texture=self.load_tilemap_textures[190],
+                texture=self.load_tilemap_textures[100],
                 scale=SPRITE_SCALING, 
                 center_x = layer_tile.center_x,
                 center_y = layer_tile.center_y,
@@ -173,31 +173,26 @@ class GameView(arcade.View):
         Movement and game logic
         """
 
-        # Calculate player speed based on the keys pressed
-        self.player.change_x = 0
-
-        
-        self.goal_sprite_list.update()
-
-        
-        goal_hit_list = arcade.check_for_collision_with_list(self.player, self.goal_sprite_list)
-
-        for g in goal_hit_list:
-            # Remove the goal
-            g.remove_from_sprite_lists()
-
-        """
         # Movement using joystick is not correct. Still here if we want to implement joystick later
         # Move player with joystick if present
+        """
         if self.joystick:
             self.player.change_x = round(self.joystick.x) * PLAYER_SPEED_X
         """
+
+        self.goal_sprite_list.update()
 
         # Update player sprite
         self.player.on_update(delta_time)
 
         # Physics engine takes a step
         self.pe.step()
+
+        goal_hit_list = arcade.check_for_collision_with_list(self.player, self.goal_sprite_list)
+        
+        for g in goal_hit_list:
+            # Remove the goal
+            g.remove_from_sprite_lists()
 
         # The game is over when the player touches all goals
         if not any(self.goal_sprite_list):

--- a/my_game.py
+++ b/my_game.py
@@ -226,6 +226,7 @@ class GameView(arcade.View):
         if key == arcade.key.UP:
             self.up_pressed = True
             new_pp = (new_pp[0], new_pp[1] + TILE_SIZE)
+            print(new_pp)
         elif key == arcade.key.DOWN:
             self.down_pressed = True
             new_pp = (new_pp[0], new_pp[1] - TILE_SIZE)

--- a/my_game.py
+++ b/my_game.py
@@ -179,15 +179,19 @@ class GameView(arcade.View):
         
         self.goal_sprite_list.update()
 
-        #goal_hit_list = arcade.check_for_collision_with_list(self.player, self.goal_sprite_list)
+        
+        #Why
+        goal_hit_list = arcade.check_for_collision_with_list(self.player, self.goal_sprite_list)
 
-        #for g in goal_hit_list:
+        for g in goal_hit_list:
             # Remove the goal
-        #    g.remove_from_sprite_lists()
+            g.remove_from_sprite_lists()
 
+        """
         # Move player with joystick if present
         if self.joystick:
             self.player.change_x = round(self.joystick.x) * PLAYER_SPEED_X
+        """
 
         # Update player sprite
         self.player.on_update(delta_time)
@@ -226,7 +230,6 @@ class GameView(arcade.View):
         if key == arcade.key.UP:
             self.up_pressed = True
             new_pp = (new_pp[0], new_pp[1] + TILE_SIZE)
-            print(new_pp)
         elif key == arcade.key.DOWN:
             self.down_pressed = True
             new_pp = (new_pp[0], new_pp[1] - TILE_SIZE)


### PR DESCRIPTION
When player moves from tile to tile, it moves with a distance equal to the tile size, and not the "magic" number 30.
The player doesn't go off-grid anymore.

*I'm very much aware of the misleading branch name*